### PR TITLE
Fixed php 5.2 incompatibility

### DIFF
--- a/Resources/skeleton/app/SymfonyRequirements.php
+++ b/Resources/skeleton/app/SymfonyRequirements.php
@@ -552,10 +552,10 @@ class SymfonyRequirements extends RequirementCollection
             require_once __DIR__.'/../vendor/autoload.php';
 
             try {
-                $r = new \ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
+                $r = new ReflectionClass('Sensio\Bundle\DistributionBundle\SensioDistributionBundle');
 
                 $contents = file_get_contents(dirname($r->getFileName()).'/Resources/skeleton/app/SymfonyRequirements.php');
-            } catch (\ReflectionException $e) {
+            } catch (ReflectionException $e) {
                 $contents = '';
             }
             $this->addRecommendation(


### PR DESCRIPTION
Removed global namespace prefix "\" from ReflectionClass and ReflectionException
